### PR TITLE
Add new input to GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,11 @@ inputs:
     required: false
     default: "."
 
+  force:
+    description: "Whether to force the operation. Passed as --force flag to multi run command."
+    required: false
+    default: "false"
+
 outputs:
   output-string:
     description: 'Output string'
@@ -64,4 +69,4 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       if: ${{ inputs.install-only != 'true' && inputs.dry-run != 'true' }}
-      run: "multi run --enable-colors=always"
+      run: "multi run --enable-colors=always --force='${{ inputs.force }}'"


### PR DESCRIPTION
- Add force input with default value false
- Pass force flag to multi run command as --force=true/false
- Allows users to control the force behavior of the multi binary