### PR TITLE
Fix force parameter in GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,4 +69,4 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       if: ${{ inputs.install-only != 'true' && inputs.dry-run != 'true' }}
-      run: "multi run --enable-colors=always --force='${{ inputs.force }}'"
+      run: "multi run --enable-colors=always ${{ inputs.force == 'true' && '--force' || '' }}"


### PR DESCRIPTION
The multi CLI expects --force as a flag (not --force=true/false). Now conditionally includes --force only when input is 'true'.